### PR TITLE
Modify events processor to use OrderByVersionStep

### DIFF
--- a/aptos-indexer-processor-example/Cargo.lock
+++ b/aptos-indexer-processor-example/Cargo.lock
@@ -149,8 +149,9 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-processor-sdk"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=ca658a0881c4bff4e1dee14c59a7c63608a5b315#ca658a0881c4bff4e1dee14c59a7c63608a5b315"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=95d76e07dd66a20a0e50a9e6c559885bff7ab52b#95d76e07dd66a20a0e50a9e6c559885bff7ab52b"
 dependencies = [
+ "ahash",
  "anyhow",
  "aptos-indexer-transaction-stream",
  "aptos-protos",
@@ -181,7 +182,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-processor-sdk-server-framework"
 version = "1.0.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=ca658a0881c4bff4e1dee14c59a7c63608a5b315#ca658a0881c4bff4e1dee14c59a7c63608a5b315"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=95d76e07dd66a20a0e50a9e6c559885bff7ab52b#95d76e07dd66a20a0e50a9e6c559885bff7ab52b"
 dependencies = [
  "anyhow",
  "aptos-indexer-processor-sdk",
@@ -205,7 +206,7 @@ dependencies = [
 [[package]]
 name = "aptos-indexer-transaction-stream"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=ca658a0881c4bff4e1dee14c59a7c63608a5b315#ca658a0881c4bff4e1dee14c59a7c63608a5b315"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=95d76e07dd66a20a0e50a9e6c559885bff7ab52b#95d76e07dd66a20a0e50a9e6c559885bff7ab52b"
 dependencies = [
  "anyhow",
  "aptos-moving-average",
@@ -226,7 +227,7 @@ dependencies = [
 [[package]]
 name = "aptos-moving-average"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=ca658a0881c4bff4e1dee14c59a7c63608a5b315#ca658a0881c4bff4e1dee14c59a7c63608a5b315"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=95d76e07dd66a20a0e50a9e6c559885bff7ab52b#95d76e07dd66a20a0e50a9e6c559885bff7ab52b"
 dependencies = [
  "chrono",
 ]
@@ -1510,7 +1511,7 @@ dependencies = [
 [[package]]
 name = "instrumented-channel"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=ca658a0881c4bff4e1dee14c59a7c63608a5b315#ca658a0881c4bff4e1dee14c59a7c63608a5b315"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=95d76e07dd66a20a0e50a9e6c559885bff7ab52b#95d76e07dd66a20a0e50a9e6c559885bff7ab52b"
 dependencies = [
  "delegate",
  "derive_builder",
@@ -2648,7 +2649,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 [[package]]
 name = "sample"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=ca658a0881c4bff4e1dee14c59a7c63608a5b315#ca658a0881c4bff4e1dee14c59a7c63608a5b315"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processor-sdk.git?rev=95d76e07dd66a20a0e50a9e6c559885bff7ab52b#95d76e07dd66a20a0e50a9e6c559885bff7ab52b"
 dependencies = [
  "tracing",
 ]

--- a/aptos-indexer-processor-example/Cargo.toml
+++ b/aptos-indexer-processor-example/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 [dependencies]
 ahash = { version = "0.8.7", features = ["serde"] }
 anyhow = "1.0.86"
-aptos-indexer-processor-sdk = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "ca658a0881c4bff4e1dee14c59a7c63608a5b315" }
-aptos-indexer-processor-sdk-server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "ca658a0881c4bff4e1dee14c59a7c63608a5b315" }
+aptos-indexer-processor-sdk = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "95d76e07dd66a20a0e50a9e6c559885bff7ab52b" }
+aptos-indexer-processor-sdk-server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processor-sdk.git", rev = "95d76e07dd66a20a0e50a9e6c559885bff7ab52b" }
 async-trait = "0.1.80"
 chrono = { version = "0.4.19", features = ["clock", "serde"] }
 clap = { version = "4.3.5", features = ["derive", "unstable-styles"] }

--- a/aptos-indexer-processor-example/src/processors/events/events_storer.rs
+++ b/aptos-indexer-processor-example/src/processors/events/events_storer.rs
@@ -55,13 +55,13 @@ fn insert_events_query(
 #[async_trait]
 impl Processable for EventsStorer {
     type Input = Vec<EventModel>;
-    type Output = Vec<EventModel>;
+    type Output = ();
     type RunType = AsyncRunType;
 
     async fn process(
         &mut self,
         events: TransactionContext<Vec<EventModel>>,
-    ) -> Result<Option<TransactionContext<Vec<EventModel>>>, ProcessorError> {
+    ) -> Result<Option<TransactionContext<()>>, ProcessorError> {
         let per_table_chunk_sizes: AHashMap<String, usize> = AHashMap::new();
         let execute_res = execute_in_chunks(
             self.conn_pool.clone(),
@@ -81,7 +81,10 @@ impl Processable for EventsStorer {
                 error!("Failed to store events: {:?}", e);
             }
         }
-        Ok(Some(events))
+        Ok(Some(TransactionContext {
+            data: (),
+            metadata: events.metadata,
+        }))
     }
 }
 


### PR DESCRIPTION
## Description
This PR updates the aptos-indexer-processor-sdk dependency to version 95d76e07 and refactors the events processor for improved functionality:

- Add OrderByVersionStep to EventsProcessor pipeline
- Simplify LatestVersionProcessedTracker implementation:
  - Remove gap detection and out-of-order processing
  - Assume inputs are ordered by starting version

## Testing 
Run processor locally